### PR TITLE
Support dependabot while using private repositories as dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,38 @@ jobs:
 
       - name: Setup Git
         uses: frequenz-floss/gh-action-setup-git@v0.x.x
-        with:
-          username: ${{ secrets.GIT_USER }}
-          password: ${{ secrets.GIT_PASS }}
 ```
 
-By default, the action will configure the user name and email to impersonate
-the GitHub Actions bot when new commits are created.
+This will configure the user name and email to impersonate the GitHub Actions
+bot when new commits are created. No credentials are configured by default.
 
-If you want to use a different user name and email, you can specify them as
-follows:
+## Inputs
+
+* `username`: The username to use for authentication.
+* `password`: The password to use for authentication.
+* `name`: The name to use for the Git user. Defaults to "GitHub Actions".
+* `email`: The email to use for the Git user. Defaults to the GitHub Actions
+  bot email.
+
+If any of `username` and `password` are provided, then Git will be configured
+to use them for authentication. Otherwise, no credentials will be configured.
+
+## Dependabot and private repositories as dependencies
+
+If you use dependabot and have private repositories as dependencies, the
+credentials configured here will have no effect on PRs created by dependabot,
+as [they don't have access to secrets][secrets-access] for [security
+reasons][pwn-requests].
+
+To fix this, you need to configure your GitHub organization to [allow
+dependabot access to the private repositories][dependabot-access] you use as
+dependencies for other projects.
+
+[secrets-access]: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+[pwn-requests]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+[dependabot-access]: https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-security-and-analysis-settings-for-your-organization#allowing-dependabot-to-access-private-dependencies
+
+## Full example
 
 ```yaml
 jobs:
@@ -44,3 +66,9 @@ jobs:
           name: "John Doe"
           email: "john.doe@example.com"
 ```
+
+## Changelog
+
+Please see the
+[releases](https://github.com/frequenz-floss/gh-action-setup-git/releases/)
+page.

--- a/action.yaml
+++ b/action.yaml
@@ -25,16 +25,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Git
+    - name: Setup Git user name and e-mail
       shell: bash
       env:
         NAME: ${{ inputs.name }}
         EMAIL: ${{ inputs.email }}
-        USER: ${{ inputs.username }}
-        PASS: ${{ inputs.password }}
       run: |
         set -u
         git config --global user.name "$NAME"
         git config --global user.email "$EMAIL"
+
+    - name: Setup Git credentials
+      if: ${{ inputs.username != '' || inputs.password != '' }}
+      shell: bash
+      env:
+        USER: ${{ inputs.username }}
+        PASS: ${{ inputs.password }}
+      run: |
+        set -u
         echo "https://$USER:$PASS@github.com" > ~/.git-credentials
         git config --global credential.helper store

--- a/action.yaml
+++ b/action.yaml
@@ -8,11 +8,13 @@ inputs:
   username:
     description: >
       The username to use to authenticate with Git.
-    required: true
+    required: false
+    default: ""
   password:
     description: >
       The password to use to authenticate with Git.
-    required: true
+    required: false
+    default: ""
   name:
     description: >
       The name to use for Git commits. This is the name that will be used to

--- a/action.yaml
+++ b/action.yaml
@@ -6,17 +6,25 @@ author: "Frequenz Energy-as-a-Service GmbH"
 # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
 inputs:
   username:
-    description: "The username to use to authenticate with Git"
+    description: >
+      The username to use to authenticate with Git.
     required: true
   password:
-    description: "The password to use to authenticate with Git"
+    description: >
+      The password to use to authenticate with Git.
     required: true
   name:
-    description: "The name to use for Git commits"
+    description: >
+      The name to use for Git commits. This is the name that will be used to
+      identify the author of the commit. By default the "GitHub Actions" bot
+      name is used.
     required: false
     default: "GitHub Actions"
   email:
-    description: "The e-mail address to use for Git commits"
+    description: >
+      The e-mail address to use for Git commits. This is the e-mail address
+      that will be used to identify the author of the commit. By default the
+      "GitHub Actions" bot e-mail address is used.
     required: false
     default: "41898282+github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
We don't setup credentials if they are empty to allow dependabot to work with private dependencies.  A PR created by dependabot won't have access to the secrets, so the inputs will be there but empty, causing to create an credentials file with no username or password, which ends up in an auth error.

Because of this, now credentials are optional, which also allows using the action with public repositories more conveniently.

To use private repos as dependencies, they must be configured in the organization.

If you use dependabot and have private repositories as dependencies, the credentials configured here will have no effect on PRs created by dependabot, as [they don't have access to secrets][secrets-access] for [security reasons][pwn-requests].

To fix this, you need to configure your GitHub organization to [allow dependabot access to the private repositories][dependabot-access] you use as dependencies for other projects.

[secrets-access]: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
[pwn-requests]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
[dependabot-access]: https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-security-and-analysis-settings-for-your-organization#allowing-dependabot-to-access-private-dependencies
